### PR TITLE
alter github id to github username

### DIFF
--- a/src/components/setting/integration/code.vue
+++ b/src/components/setting/integration/code.vue
@@ -90,10 +90,10 @@
                       auto-complete="off"></el-input>
           </el-form-item>
           <el-form-item v-if="codeEdit.type==='github'"
-                        label="Organization(Or GitHub ID)"
+                        label="Organization(Or GitHub Username)"
                         prop="namespace">
             <el-input v-model="codeEdit.namespace"
-                      placeholder="Organization(Or GitHub ID)"
+                      placeholder="Organization(Or GitHub Username)"
                       auto-complete="off"></el-input>
           </el-form-item>
         </template>
@@ -266,10 +266,10 @@
                       auto-complete="off"></el-input>
           </el-form-item>
           <el-form-item v-if="codeAdd.type==='github'"
-                        label="Organization(Or GitHub ID)"
+                        label="Organization(Or GitHub Username)"
                         prop="namespace">
             <el-input v-model="codeAdd.namespace"
-                      placeholder="Organization(Or GitHub ID)"
+                      placeholder="Organization(Or GitHub Username)"
                       auto-complete="off"></el-input>
           </el-form-item>
         </template>


### PR DESCRIPTION
Signed-off-by: fansi <fansi4o4@163.com>

### What this PR does / Why we need it:

the expression of github id is wrong

### What is changed and how it works?

What's Changed: alter github id to github username
