### PR TITLE
Set groupFilter is required in LDAP and AD.

### DIFF
--- a/src/components/setting/integration/account.vue
+++ b/src/components/setting/integration/account.vue
@@ -541,6 +541,11 @@ export default {
           required: true,
           message: '请输入组名称属性',
           trigger: ['blur', 'change']
+        },
+        'groupSearch.filter': {
+          required: true,
+          message: '请输入组过滤器',
+          trigger: ['blur', 'change']
         }
       },
       userAccountLDAPRules: {
@@ -592,6 +597,11 @@ export default {
         'groupSearch.nameAttr': {
           required: true,
           message: '请输入组名称属性',
+          trigger: ['blur', 'change']
+        },
+        'groupSearch.filter': {
+          required: true,
+          message: '请输入组过滤器',
           trigger: ['blur', 'change']
         }
       },


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

Set groupFilter is required.

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information