### PR TITLE
Change downloadConfigAPI's route.

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1136,7 +1136,7 @@ export function saveSubscribeAPI (payload) {
 }
 
 export function downloadConfigAPI () {
-  return http.get('/api/v1/picket/downloads/kube')
+  return http.get('/api/v1/picket/kubeconfig')
 }
 
 export function updateServiceImageAPI (payload, type, projectName, envType = '') {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1135,8 +1135,8 @@ export function saveSubscribeAPI (payload) {
   return http.post('/api/aslan/system/notification/subscribe', payload)
 }
 
-export function downloadPubKeyAPI () {
-  return http.get('/api/aslan/setting/user/kube/config')
+export function downloadConfigAPI () {
+  return http.get('/api/v1/picket/downloads/kube')
 }
 
 export function updateServiceImageAPI (payload, type, projectName, envType = '') {

--- a/src/components/profile/manage.vue
+++ b/src/components/profile/manage.vue
@@ -77,7 +77,7 @@
                                  :keyword="{location:'个人中心',key:'KubeConfig'}"></support-doc>
                   </td>
                   <td class="">
-                    <el-button @click="downloadPubKey()"
+                    <el-button @click="downloadConfig()"
                                type="text">点击下载</el-button>
                   </td>
                 </tr>
@@ -148,7 +148,7 @@
 import bus from '@utils/event_bus'
 import store from 'storejs'
 import supportDoc from './common/support_doc.vue'
-import { getCurrentUserInfoAPI, updateCurrentUserInfoAPI, getSubscribeAPI, saveSubscribeAPI, downloadPubKeyAPI } from '@api'
+import { getCurrentUserInfoAPI, updateCurrentUserInfoAPI, getSubscribeAPI, saveSubscribeAPI, downloadConfigAPI } from '@api'
 import { mapState } from 'vuex'
 
 export default {
@@ -249,14 +249,14 @@ export default {
       this.$refs.ruleForm.resetFields()
       this.modifiedPwdDialogVisible = false
     },
-    downloadPubKey () {
+    downloadConfig () {
       this.$message({
-        message: '私钥获取中，请稍候...',
+        message: '获取配置中，请稍候...',
         type: 'info'
       })
-      downloadPubKeyAPI().then((res) => {
+      downloadConfigAPI().then((res) => {
         this.$message({
-          message: '私钥获取完毕，下载后请根据文档使用',
+          message: '配置获取完毕，下载后请按照文档使用',
           type: 'success'
         })
         const content = res

--- a/src/components/profile/manage.vue
+++ b/src/components/profile/manage.vue
@@ -70,7 +70,7 @@
                     </td>
                   </tr>
                 </template>
-                <tr>
+                <!-- <tr>
                   <td>
                     <span>Kube Config</span>
                     <support-doc :inline="true"
@@ -80,7 +80,7 @@
                     <el-button @click="downloadConfig()"
                                type="text">点击下载</el-button>
                   </td>
-                </tr>
+                </tr> -->
                 <tr v-if="currentEditUserInfo.identity_type ==='system'">
                   <td>
                     <span>修改密码


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

- Change downloadConfigAPI's route.
- Don't show kubeconfig download temporary. 

![image](https://user-images.githubusercontent.com/6907296/143864309-42db45c3-603e-405c-9a98-806679259a97.png)



### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information