### PR TITLE
Add tooltip to repo name.

### DIFF
--- a/src/components/common/workflow_build_rows.vue
+++ b/src/components/common/workflow_build_rows.vue
@@ -16,8 +16,9 @@
             <template v-if="!build.use_default">
               <el-col :span="7">
                 <div class="repo-name-container">
-                  <span :class="{'repo-name': true}"> {{
-              $utils.tailCut(build.repo_name,20) }}</span>
+                  <el-tooltip class="item" effect="dark" :content="build.repo_name" placement="top">
+                    <span :class="{'repo-name': true}"> {{$utils.tailCut(build.repo_name,20) }}</span>
+                  </el-tooltip>
                 </div>
               </el-col>
               <template v-if="build.showBranch">

--- a/src/components/common/workflow_test_rows.vue
+++ b/src/components/common/workflow_test_rows.vue
@@ -16,8 +16,9 @@
             <template v-if="!build.use_default">
               <el-col :span="7">
                 <div class="repo-name-container">
-                  <span :class="{'repo-name': true}"> {{
-              $utils.tailCut(build.repo_name,20) }}</span>
+                  <el-tooltip class="item" effect="dark" :content="build.repo_name" placement="top">
+                    <span :class="{'repo-name': true}"> {{$utils.tailCut(build.repo_name,20) }}</span>
+                  </el-tooltip>
                 </div>
               </el-col>
               <template>


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

- Add tooltip to repo name.
- Show fullname when reponame is too long.

What's Changed:

- workflow_test_rows.vue
- workflow_build_rows.vue

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information