### PR TITLE
fix(log):Change SSE log heartbeat timeout to 3600s

### DIFF
--- a/src/common/vue_sse/index.js
+++ b/src/common/vue_sse/index.js
@@ -12,13 +12,15 @@ export default {
         {},
         {
           withCredentials: false,
-          format: 'plain'
+          format: 'plain',
+          heartbeatTimeout: 3600 * 1000
         },
         cfg
       )
 
       const source = new EventSource(url, {
         withCredentials: config.withCredentials,
+        heartbeatTimeout: config.heartbeatTimeout || 45000,
         headers: {
           Authorization: 'Bearer ' + store.get('userInfo').token
         }


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

Change SSE log heartbeat timeout to 3600s

### What is changed and how it works?

The default timeout period without output is 45 seconds, which is too short to break.
![Uploading image.png…]()

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information