### PR TITLE
feat(console):show build info in console when environment's type is production.

### DIFF
--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -3,5 +3,6 @@ module.exports = {
   NODE_ENV: '"production"',
   VERSION: '"${VERSION}"',
   BUILD_TIME: '"${BUILD_TIME}"',
-  TAG: '"${TAG}"'
+  TAG: '"${TAG}"',
+  COMMIT_ID: '"${COMMIT_ID}"'
 }

--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -4,5 +4,7 @@ module.exports = {
   VERSION: '"${VERSION}"',
   BUILD_TIME: '"${BUILD_TIME}"',
   TAG: '"${TAG}"',
-  COMMIT_ID: '"${COMMIT_ID}"'
+  COMMIT_ID: '"${COMMIT_ID}"',
+  BRANCH: '"${BRANCH}"',
+  PR: '"${PR}"',
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script>
+import moment from 'moment'
 export default {
   computed: {
     processEnv () {
@@ -17,19 +18,27 @@ export default {
     }
   },
   mounted () {
-    if (this.processEnv && this.processEnv.NODE_ENV === 'production') {
+    if (this.processEnv && this.processEnv.NODE_ENV === 'development') {
       console.log('%cHello ZADIG！', 'color: #e20382;font-size: 13px;')
+      const buildInfo = []
       if (this.processEnv.VERSION) {
-        console.log(`%cVersion:${this.processEnv.VERSION}`, 'color: #e20382;font-size: 13px;')
+        buildInfo.push(`${this.processEnv.VERSION}`)
       }
       if (this.processEnv.TAG) {
-        console.log(`%cCommit:${this.processEnv.TAG}`, 'color: #e20382;font-size: 13px;')
+        buildInfo.push(`Tag:${this.processEnv.TAG}`)
+      }
+      if (this.processEnv.BRANCH) {
+        buildInfo.push(`Branch：${this.processEnv.BRANCH}`)
+      }
+      if (this.processEnv.PR) {
+        buildInfo.push(`PR：${this.processEnv.PR}`)
       }
       if (this.processEnv.COMMIT_ID) {
-        console.log(`%cCommit:${this.processEnv.COMMIT_ID}`, 'color: #e20382;font-size: 13px;')
+        buildInfo.push(`Commit：${this.processEnv.COMMIT_ID}`)
       }
+      console.log(`%cBuild:${buildInfo.join(' ')}`, 'color: #e20382;font-size: 13px;')
       if (this.processEnv.BUILD_TIME) {
-        console.log(`%cBuild:${this.processEnv.BUILD_TIME}`, 'color: #e20382;font-size: 13px;')
+        console.log(`%cTime:${moment.unix(this.processEnv.BUILD_TIME).format('YYYYMMDDHHmm')}`, 'color: #e20382;font-size: 13px;')
       }
     }
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,27 @@
 
 <script>
 export default {
-  methods: {
-  },
   computed: {
-
+    processEnv () {
+      return process.env
+    }
+  },
+  mounted () {
+    if (this.processEnv && this.processEnv.NODE_ENV === 'production') {
+      console.log('%cHello ZADIG！', 'color: #e20382;font-size: 13px;')
+      if (this.processEnv.VERSION) {
+        console.log(`%cVersion:${this.processEnv.VERSION}`, 'color: #e20382;font-size: 13px;')
+      }
+      if (this.processEnv.TAG) {
+        console.log(`%cCommit:${this.processEnv.TAG}`, 'color: #e20382;font-size: 13px;')
+      }
+      if (this.processEnv.COMMIT_ID) {
+        console.log(`%cCommit:${this.processEnv.COMMIT_ID}`, 'color: #e20382;font-size: 13px;')
+      }
+      if (this.processEnv.BUILD_TIME) {
+        console.log(`%cBuild:${this.processEnv.BUILD_TIME}`, 'color: #e20382;font-size: 13px;')
+      }
+    }
   }
 }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,23 +18,23 @@ export default {
     }
   },
   mounted () {
-    if (this.processEnv && this.processEnv.NODE_ENV === 'development') {
+    if (this.processEnv && this.processEnv.NODE_ENV === 'production') {
       console.log('%cHello ZADIG！', 'color: #e20382;font-size: 13px;')
       const buildInfo = []
       if (this.processEnv.VERSION) {
         buildInfo.push(`${this.processEnv.VERSION}`)
       }
       if (this.processEnv.TAG) {
-        buildInfo.push(`Tag:${this.processEnv.TAG}`)
+        buildInfo.push(`Tag-${this.processEnv.TAG}`)
       }
       if (this.processEnv.BRANCH) {
-        buildInfo.push(`Branch：${this.processEnv.BRANCH}`)
+        buildInfo.push(`Branch-${this.processEnv.BRANCH}`)
       }
       if (this.processEnv.PR) {
-        buildInfo.push(`PR：${this.processEnv.PR}`)
+        buildInfo.push(`PR-${this.processEnv.PR}`)
       }
       if (this.processEnv.COMMIT_ID) {
-        buildInfo.push(`Commit：${this.processEnv.COMMIT_ID}`)
+        buildInfo.push(`${this.processEnv.COMMIT_ID.substring(0, 7)}`)
       }
       console.log(`%cBuild:${buildInfo.join(' ')}`, 'color: #e20382;font-size: 13px;')
       if (this.processEnv.BUILD_TIME) {


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

![image](https://user-images.githubusercontent.com/6907296/145950223-530458cf-2a18-426f-957c-1e07744e576a.png)

How it Works:

Show info when app is mounted when environment's type is production.

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information