### PR TITLE
fix: cant create env when don't add image registry

### DIFF
--- a/src/components/projects/env/inner_env/create_env_detail.vue
+++ b/src/components/projects/env/inner_env/create_env_detail.vue
@@ -886,7 +886,8 @@ export default {
     getRegistryWhenBuildAPI(this.projectName).then(res => {
       this.imageRegistry = res
       if (!this.projectConfig.registry_id) {
-        this.projectConfig.registry_id = res.find(reg => reg.is_default).id
+        const defaultRegistry = res.find(reg => reg.is_default)
+        this.projectConfig.registry_id = defaultRegistry ? defaultRegistry.id : ''
       }
       this.getTemplateAndImg()
     })


### PR DESCRIPTION
Signed-off-by: Jody <qizhaodi@koderover.com>

### What this PR does / Why we need it:

- cant create env when don't add image registry

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information