### PR TITLE
fix:set is_default is true when registry not exists.

### DIFF
--- a/src/components/setting/registry/manage.vue
+++ b/src/components/setting/registry/manage.vue
@@ -263,11 +263,6 @@ export default {
   },
   methods: {
     addRegistryBtn () {
-      if (this.allRegistry.length === 0) {
-        this.registry.is_default = true
-      } else {
-        this.registry.is_default = false
-      }
       this.registry = {
         namespace: '',
         reg_addr: '',
@@ -275,7 +270,7 @@ export default {
         secret_key: '',
         reg_provider: '',
         region: '',
-        is_default: false
+        is_default: this.allRegistry.length === 0
       }
       this.mode = 'create'
       this.dialogRegistryFormVisible = true


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

set is_default is true when registry not exists

### Check List <!--REMOVE the items that are not applicable-->

- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information