### PR TITLE
fix: default image registry can't delete and default selected if has …

### DIFF
--- a/src/components/setting/registry/manage.vue
+++ b/src/components/setting/registry/manage.vue
@@ -270,7 +270,7 @@ export default {
         secret_key: '',
         reg_provider: '',
         region: '',
-        is_default: this.allRegistry.length === 0
+        is_default: this.allRegistry.filter(registry => registry.is_default).length === 0
       }
       this.mode = 'create'
       this.dialogRegistryFormVisible = true
@@ -328,6 +328,13 @@ export default {
         })
       } else if (action === 'delete') {
         const id = registry.id
+        if (registry.is_default) {
+          this.$alert(`默认镜像仓库 ${registry.namespace} 不可被删除！`, '取消', {
+            confirmButtonText: '取消',
+            type: 'warning'
+          })
+          return
+        }
         this.$confirm(`确定要删除 ${registry.namespace} ?`, '确认', {
           confirmButtonText: '确定',
           cancelButtonText: '取消',


### PR DESCRIPTION
Signed-off-by: Jody <qizhaodi@koderover.com>

### What this PR does / Why we need it:

fix: 
- default image registry can't delete if registry more than one 
- default selected if has not default registry

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information