### PR TITLE
fix(repo_select):Fix the problem that the repo_name is empty when man…

### DIFF
--- a/src/common/repo_select.vue
+++ b/src/common/repo_select.vue
@@ -421,6 +421,7 @@ export default {
         this.setLoadingState(index, 'branch', true)
         getBranchInfoByIdAPI(id, repo_owner, repo_name, repoUUID, 1, 200, key).then((res) => {
           this.$set(this.codeInfo[index], 'branches', res || [])
+          this.$set(this.codeInfo[index], 'origin_branches', res || [])
           this.setLoadingState(index, 'branch', false)
         })
       }
@@ -474,6 +475,7 @@ export default {
           })
           getBranchInfoByIdAPI(codehostId, repoOwner, repoName, uuid).then((res) => {
             this.$set(this.codeInfo[index], 'branches', res || [])
+            this.$set(this.codeInfo[index], 'origin_branches', res || [])
           })
         }
       })
@@ -499,10 +501,8 @@ export default {
       if (codehostType === 'gitlab') {
         this.getBranchInfoById(index, id, repoOwner, repoName, query)
       } else {
-        const items = this.$utils.filterObjectArrayByKey('name', query, this.codeInfo[index].origin_repos)
-        this.$set(this.codeInfo[index], 'repos', items)
-        this.config.repos[index].repo_name = ''
-        this.config.repos[index].branch = ''
+        const items = this.$utils.filterObjectArrayByKey('name', query, this.codeInfo[index].origin_branches)
+        this.$set(this.codeInfo[index], 'branches', items)
       }
     },
     changeToPrimaryRepo (index, val) {


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

Fix the problem that the repo_name is empty when manually creating branches.

### Problem Summary:

The repo_name will be cleared when the branch is created.

Influence of scope:

- Non GitLab Repos

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information