### PR TITLE
support `Prepare` state for build/testing

### DIFF
--- a/src/components/projects/pipeline/workflow_multi_task_detail.vue
+++ b/src/components/projects/pipeline/workflow_multi_task_detail.vue
@@ -899,7 +899,7 @@ export default {
       if (this.$utils.isEmpty(subTask) || subTask.status === '') {
         return 0
       }
-      const endTime = subTask.status === 'running' ? Math.floor(Date.now() / 1000) : subTask.end_time
+      const endTime = (subTask.status === 'running' || subTask.status === 'prepare') ? Math.floor(Date.now() / 1000) : subTask.end_time
       return endTime - subTask.start_time
     },
     makePrettyElapsedTime (subTask) {

--- a/src/components/projects/pipeline/workflow_multi_task_detail/task_detail_build.vue
+++ b/src/components/projects/pipeline/workflow_multi_task_detail/task_detail_build.vue
@@ -36,14 +36,14 @@
                  href="#buildv2-log">{{buildv2.status?buildOverallStatusZh:"未运行"}}</a>
             </div>
           </el-col>
-          <el-col v-if="buildv2.status!=='running'"
-                  :span="6">
+          <el-col v-if="buildv2.status!=='running' && buildv2.status!=='prepare'"
+            :span="6">
             <div class="grid-content item-title">
               <i class="iconfont iconshijian"></i> 持续时间
             </div>
           </el-col>
-          <el-col v-if="buildv2.status!=='running'"
-                  :span="6">
+          <el-col v-if="buildv2.status!=='running' && buildv2.status!=='prepare'"
+            :span="6">
             <span
                   class="item-desc">{{$utils.timeFormat(buildv2.end_time - buildv2.start_time)}}</span>
           </el-col>

--- a/src/components/projects/test/common/function/container/task_detail_test.vue
+++ b/src/components/projects/test/common/function/container/task_detail_test.vue
@@ -38,14 +38,14 @@
               </a>
             </div>
           </el-col>
-          <el-col v-if="testingv2.status!=='running'"
-                  :span="6">
+          <el-col v-if="testingv2.status!=='running' && testingv2.status!=='prepare'"
+            :span="6">
             <div class="grid-content item-title">
               <i class="iconfont iconshijian"></i> 持续时间
             </div>
           </el-col>
-          <el-col v-if="testingv2.status!=='running'"
-                  :span="6">
+          <el-col v-if="testingv2.status!=='running' && testingv2.status!=='prepare'"
+            :span="6">
             <span class="item-desc">{{$utils.timeFormat(testingv2.end_time -
               testingv2.start_time)}}</span>
           </el-col>

--- a/src/components/projects/test/common/function/functionTaskDetail.vue
+++ b/src/components/projects/test/common/function/functionTaskDetail.vue
@@ -251,7 +251,7 @@ export default {
       if (this.$utils.isEmpty(subTask) || subTask.status === '') {
         return 0
       }
-      const endTime = subTask.status === 'running' ? Math.floor(Date.now() / 1000) : subTask.end_time
+      const endTime = (subTask.status === 'running' || subTask.status === 'prepare') ? Math.floor(Date.now() / 1000) : subTask.end_time
       return endTime - subTask.start_time
     },
     makePrettyElapsedTime (subTask) {

--- a/src/utilities/wordTranslate.js
+++ b/src/utilities/wordTranslate.js
@@ -31,7 +31,8 @@ export function wordTranslate (word, category, subitem = '') {
         cancelled: '取消',
         blocked: '阻塞',
         queued: '队列中',
-        skipped: '跳过'
+        skipped: '跳过',
+        prepare: '准备环境'
       }
     },
     project: {


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

The back-end adds a `Prepare` state for the build and testing process, and the front-end adapts accordingly. 

### What is changed and how it works?

Support `Prepare` state for the build and testing process.

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information