### PR TITLE
Disable global proxy switch and replace it with a switch for each entry

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -3,7 +3,7 @@
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require('path');
-const backEndAddr = '';
+const backEndAddr = 'http://dev2.8slan.com';
 
 module.exports = {
   dev: {

--- a/config/index.js
+++ b/config/index.js
@@ -3,7 +3,7 @@
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require('path');
-const backEndAddr = 'http://dev2.8slan.com';
+const backEndAddr = '';
 
 module.exports = {
   dev: {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -733,6 +733,10 @@ export function createCodeSourceAPI (payload) {
   return http.post(`/api/v1/codehosts`, payload)
 }
 
+export function getCodeSourceAPI (code_source_id) {
+  return http.get(`/api/v1/codehosts/${code_source_id}`)
+}
+
 export function deleteCodeSourceAPI (code_source_id) {
   return http.delete(`/api/v1/codehosts/${code_source_id}`)
 }

--- a/src/common/repo_select.vue
+++ b/src/common/repo_select.vue
@@ -27,7 +27,7 @@
               <el-select v-model="config.repos[repo_index].codehost_id"
                          size="small"
                          placeholder="请选择托管平台"
-                         @change="getRepoOwnerById(repo_index,config.repos[repo_index].codehost_id)"
+                         @change="selectRepoAndGetOwner(repo_index,config.repos[repo_index].codehost_id)"
                          filterable>
                 <el-option v-for="(host,index) in allCodeHosts"
                            :key="index"
@@ -219,7 +219,7 @@
 </template>
 
 <script type="text/javascript">
-import { getCodeSourceMaskedAPI, getRepoOwnerByIdAPI, getRepoNameByIdAPI, getBranchInfoByIdAPI } from '@api'
+import { getCodeSourceMaskedAPI, getRepoOwnerByIdAPI, getRepoNameByIdAPI, getBranchInfoByIdAPI, getCodeSourceAPI } from '@api'
 import { orderBy } from 'lodash'
 export default {
   data () {
@@ -432,6 +432,13 @@ export default {
       this.$set(this.config.repos[index], 'repo_uuid', repoUUID)
       this.$set(this.config.repos[index], 'repo_id', repoId)
       this.config.repos[index].branch = ''
+    },
+    selectRepoAndGetOwner (index, id, key = '') {
+      // first we get the basic information about the codehost
+      getCodeSourceAPI(id).then((res) => {
+        this.config.repos[index].enable_proxy = res.enable_proxy
+      })
+      this.getRepoOwnerById(index, id, key)
     },
     getRepoOwnerById (index, id, key = '') {
       if (!key) {

--- a/src/common/repo_select.vue
+++ b/src/common/repo_select.vue
@@ -316,7 +316,8 @@ export default {
         branch: '',
         checkout_path: '',
         remote_name: 'origin',
-        submodules: false
+        submodules: false,
+        enable_proxy: false
       }
       this.showTrigger && (repoMeta.enableTrigger = false)
       this.validateForm().then(res => {
@@ -330,6 +331,7 @@ export default {
         if (this.allCodeHosts && this.allCodeHosts.length === 1) {
           const codeHostId = this.allCodeHosts[0].id
           repoMeta.codehost_id = codeHostId
+          repoMeta.enable_proxy = this.allCodeHosts[0].enable_proxy
           this.getRepoOwnerById(index + 1, codeHostId)
         }
       }).catch(err => {
@@ -344,7 +346,8 @@ export default {
         branch: '',
         checkout_path: '',
         remote_name: 'origin',
-        submodules: false
+        submodules: false,
+        enable_proxy: false
       }
       this.showTrigger && (repoMeta.enableTrigger = false)
       this.$set(this.codeInfo, 0, {
@@ -356,6 +359,7 @@ export default {
       if (this.allCodeHosts && this.allCodeHosts.length === 1) {
         const codeHostId = this.allCodeHosts[0].id
         repoMeta.codehost_id = codeHostId
+        repoMeta.enable_proxy = this.allCodeHosts[0].enable_proxy
         this.getRepoOwnerById(0, codeHostId)
       }
       this.config.repos.push(repoMeta)

--- a/src/components/setting/config/proxy.vue
+++ b/src/components/setting/config/proxy.vue
@@ -25,7 +25,8 @@
         <el-form-item prop="type"
                       label="类型">
           <el-select v-model="proxyInfo.type"
-                     size="small">
+                     size="small"
+                     @change="changeProxy">
             <el-option label="不使用代理"
                        value="no"></el-option>
             <el-option label="HTTP 代理"
@@ -205,6 +206,15 @@ export default {
         this.noPost = false
         this.$message.error(`获取代理配置失败：${error}`)
       })
+    },
+    // if proxy is unset, then turn off repo proxy
+    // otherwise repo proxy is ALWAYS on
+    changeProxy () {
+      if (this.proxyInfo.type === 'no') {
+        this.proxyInfo.enable_repo_proxy = false
+      } else {
+        this.proxyInfo.enable_repo_proxy = true
+      }
     }
   },
   activated () {

--- a/src/components/setting/integration/code.vue
+++ b/src/components/setting/integration/code.vue
@@ -159,7 +159,12 @@
           </el-form-item>
 
         </template>
-
+        <template>
+          <span class="switch-span">启用代理</span>
+          <el-switch size="small"
+                     v-model="codeEdit.enable_proxy"
+                     @change="changeProxy"></el-switch>
+        </template>
       </el-form>
       <div slot="footer"
            class="dialog-footer">
@@ -333,6 +338,12 @@
                       auto-complete="off"></el-input>
           </el-form-item>
         </template>
+        <template>
+          <span class="switch-span">启用代理</span>
+          <el-switch size="small"
+                     v-model="codeAdd.enable_proxy"
+                     @change="changeProxy"></el-switch>
+        </template>
       </el-form>
       <div slot="footer"
            class="dialog-footer">
@@ -369,11 +380,6 @@
                      size="small"
                      @click="handleCodeAdd"
                      plain>添加</el-button>
-          <span class="switch-span"
-                :style="{color: proxyInfo.enable_repo_proxy?'#409EFF':'#303133'}">启用代理</span>
-          <el-switch size="small"
-                     :value="proxyInfo.enable_repo_proxy"
-                     @change="changeProxy"></el-switch>
         </div>
         <el-table :data="code"
                   style="width: 100%;">
@@ -421,7 +427,7 @@
 </template>
 <script>
 import {
-  getCodeProviderAPI, deleteCodeSourceAPI, updateCodeSourceAPI, createCodeSourceAPI, getProxyConfigAPI, updateProxyConfigAPI
+  getCodeProviderAPI, deleteCodeSourceAPI, updateCodeSourceAPI, createCodeSourceAPI, getProxyConfigAPI
 } from '@api'
 const validateGitURL = (rule, value, callback) => {
   if (value === '') {
@@ -458,7 +464,8 @@ export default {
         address: '',
         access_token: '',
         application_id: '',
-        client_secret: ''
+        client_secret: '',
+        enable_proxy: false
       },
       codeAdd: {
         name: '',
@@ -639,23 +646,8 @@ export default {
       if (!this.proxyInfo.id || this.proxyInfo.type === 'no') {
         this.proxyInfo.enable_repo_proxy = false
         this.$message.error('未配置代理，请先前往「系统配置」->「代理配置」配置代理！')
-        return
+        this.codeEdit.enable_proxy = false
       }
-      this.proxyInfo.enable_repo_proxy = value
-      updateProxyConfigAPI(this.proxyInfo.id, this.proxyInfo).then(response => {
-        if (response.message === 'success') {
-          const mess = value ? '启用代理成功！' : '成功关闭代理！'
-          this.$message({
-            message: `${mess}`,
-            type: 'success'
-          })
-        } else {
-          this.$message.error(response.message)
-        }
-      }).catch(err => {
-        this.proxyInfo.enable_repo_proxy = !value
-        this.$message.error(`修改配置失败：${err}`)
-      })
     },
     getProxyConfig () {
       getProxyConfigAPI().then(response => {


### PR DESCRIPTION
### What this PR does / Why we need it:
Now users no longer has a switch for system repo proxy. They get a button to enable proxy for that specific repo.

Problem Summary:
-
### What is changed and how it works?

What's Changed:
1. Deleted enable proxy in the repository page
2. Added enable proxy for each of the repository entry. The old repositories will be marked as disabled

How it Works:

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information