### PR TITLE
enables creating env for existing namespace

### DIFF
--- a/src/components/projects/env/env_detail/components/updateHelmEnvDialog.vue
+++ b/src/components/projects/env/env_detail/components/updateHelmEnvDialog.vue
@@ -16,6 +16,9 @@
           <el-radio label="fixed">使用环境中修改过的变量（不包括镜像）覆盖新 Chart 中的变量</el-radio>
         </el-radio-group>
       </div>-->
+      <div class="overwrite-warning" v-if="this.productInfo.is_existed">
+        <p>Zadig 中定义的服务将覆盖所选命名空间中的同名服务，请谨慎操作！</p>
+      </div>
       <span slot="footer" class="dialog-footer">
         <el-button size="small" type="primary" :loading="updataHelmEnvLoading" @click="updateHelmEnv()">确 定</el-button>
         <el-button size="small" @click="updateHelmEnvDialogVisible = false">取 消</el-button>
@@ -48,7 +51,8 @@ export default {
   name: 'updateHelmEnv',
   props: {
     productInfo: Object,
-    fetchAllData: Function
+    fetchAllData: Function,
+    isExisted: Boolean
   },
   data () {
     return {
@@ -157,6 +161,11 @@ export default {
 /deep/.el-dialog {
   .el-dialog__body {
     padding: 0 10px 20px;
+  }
+
+  .overwrite-warning {
+    color: #f56c6c;
+    font-size: 13px;
   }
 
   .kr-container {


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
enables creating env for existing namespace

Problem Summary:
Currently creating environment on existing namespace is disabled, this PR removes this limit
### What is changed and how it works?

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information