### PR TITLE
feat:add envType to tab's tooltip.

### DIFF
--- a/src/common/chromeTabs.vue
+++ b/src/common/chromeTabs.vue
@@ -29,7 +29,11 @@
           <div class="custom-tab-title">
             <el-tooltip effect="dark" placement="bottom">
               <slot v-bind:tab="tab"></slot>
-              <template slot="content">{{tab.name}}</template>
+              <template slot="content">
+                <span>{{tab.name}}</span>
+                <span v-if="!_.isNil(tab.share_env_is_base) && tab.share_env_is_base" >- 基准环境</span>
+                <span v-if="!tab.share_env_is_base && !_.isNil(tab.share_env_base_env) && tab.share_env_base_env !==''">- 子环境</span>
+              </template>
             </el-tooltip>
           </div>
         </template>
@@ -37,8 +41,8 @@
     </el-tabs>
   </div>
 </template>
-
 <script>
+import _ from 'lodash'
 export default {
   model: {
     prop: 'currentTab',
@@ -53,6 +57,11 @@ export default {
   methods: {
     updateCurrent (current) {
       this.$emit('updateTab', current)
+    }
+  },
+  computed: {
+    _ () {
+      return _
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

add envType to tab's tooltip.

<img width="250" alt="image" src="https://user-images.githubusercontent.com/6907296/163117316-e6a02790-af4d-49f2-bc60-a336a8dca383.png">


### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
