### PR TITLE
feat:breadcrumb supports show project alias.

### DIFF
--- a/src/components/delivery/version/detail.vue
+++ b/src/components/delivery/version/detail.vue
@@ -36,6 +36,7 @@ export default {
           { title: '项目', url: `/v1/projects` },
           {
             title: this.projectName,
+            isProjectName: true,
             url: `/v1/projects/detail/${this.projectName}/detail`
           },
           { title: '版本管理', url: `/v1/projects/detail/${this.projectName}/version` },

--- a/src/components/delivery/version/index.vue
+++ b/src/components/delivery/version/index.vue
@@ -237,6 +237,7 @@ export default {
           { title: '项目', url: `/v1/projects` },
           {
             title: this.projectName,
+            isProjectName: true,
             url: `/v1/projects/detail/${this.projectName}/detail`
           },
           { title: '版本管理', url: `` }

--- a/src/components/entry/home/topbar.vue
+++ b/src/components/entry/home/topbar.vue
@@ -31,9 +31,8 @@
         </div>
         <div class="breadcrumb-container">
           <div class="project-switcher"></div>
-          <!-- <span v-if="content.title" class="kr-topbar-title">{{content.title}}</span> -->
           <el-breadcrumb v-if="content.breadcrumb && content.breadcrumb.length > 0" separator=">">
-            <el-breadcrumb-item v-for="(item,index) in content.breadcrumb" :to="item.url" :key="index">{{item.title}}</el-breadcrumb-item>
+            <el-breadcrumb-item v-for="(item,index) in content.breadcrumb" :to="item.url" :key="index">{{parseTitle(item)}}</el-breadcrumb-item>
           </el-breadcrumb>
         </div>
       </div>
@@ -238,6 +237,19 @@ export default {
     },
     changeTitle (params) {
       this.content = params
+    },
+    parseTitle (item) {
+      if (item.isProjectName) {
+        const project = this.projectList.find(i => {
+          return item.title === i.name
+        })
+        if (project) {
+          const alias = project.alias || project.name
+          return alias
+        }
+      } else {
+        return item.title
+      }
     }
   },
   created () {

--- a/src/components/projects/build/config.vue
+++ b/src/components/projects/build/config.vue
@@ -205,6 +205,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         { title: '构建', url: '' }

--- a/src/components/projects/build/configDetail.vue
+++ b/src/components/projects/build/configDetail.vue
@@ -59,6 +59,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         {

--- a/src/components/projects/detail_ope/detail.vue
+++ b/src/components/projects/detail_ope/detail.vue
@@ -275,7 +275,7 @@ export default {
         title: '',
         breadcrumb: [
           { title: '项目', url: '/v1/projects' },
-          { title: this.projectName, url: '' }
+          { title: this.projectName, isProjectName: true, url: '' }
         ]
       })
     }
@@ -290,7 +290,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: '' }
+        { title: this.projectName, isProjectName: true, url: '' }
       ]
     })
   }

--- a/src/components/projects/detail_ope/initialize.vue
+++ b/src/components/projects/detail_ope/initialize.vue
@@ -122,7 +122,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: '' },
+        { title: this.projectName, isProjectName: true, url: '' },
         { title: '项目资源', url: '' }
       ]
     })

--- a/src/components/projects/env/env_detail/envConfig/home.vue
+++ b/src/components/projects/env/env_detail/envConfig/home.vue
@@ -124,6 +124,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         { title: '环境', url: '' },

--- a/src/components/projects/env/inner_env/envDetail.vue
+++ b/src/components/projects/env/inner_env/envDetail.vue
@@ -27,6 +27,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         { title: '环境', url: '' }

--- a/src/components/projects/env/inner_env/pmServiceDetail.vue
+++ b/src/components/projects/env/inner_env/pmServiceDetail.vue
@@ -201,7 +201,7 @@ export default {
         title: '',
         breadcrumb: [
           { title: '项目', url: '/v1/projects' },
-          { title: this.projectName, url: `/v1/projects/detail/${this.projectName}/detail` },
+          { title: this.projectName, isProjectName: true, url: `/v1/projects/detail/${this.projectName}/detail` },
           { title: '环境', url: `/v1/projects/detail/${this.projectName}/envs/detail` },
           { title: this.envName, url: `/v1/projects/detail/${this.projectName}/envs/detail?envName=${this.envName}` },
           { title: this.serviceName, url: `` }

--- a/src/components/projects/env/inner_env/serviceConfig.vue
+++ b/src/components/projects/env/inner_env/serviceConfig.vue
@@ -74,6 +74,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         {

--- a/src/components/projects/env/inner_env/serviceDetail.vue
+++ b/src/components/projects/env/inner_env/serviceDetail.vue
@@ -802,7 +802,7 @@ export default {
         title: '',
         breadcrumb: [
           { title: '项目', url: '/v1/projects' },
-          { title: this.projectName, url: `/v1/projects/detail/${this.projectName}/detail` },
+          { title: this.projectName, isProjectName: true, url: `/v1/projects/detail/${this.projectName}/detail` },
           { title: '环境', url: `/v1/projects/detail/${this.projectName}/envs/detail` },
           { title: this.envName, url: `/v1/projects/detail/${this.projectName}/envs/detail?envName=${this.envName}` },
           { title: this.serviceName, url: '' }

--- a/src/components/projects/guide/common/runtime.vue
+++ b/src/components/projects/guide/common/runtime.vue
@@ -208,7 +208,7 @@ export default {
         this.generateEnv(this.projectName, this.envType)
       }, 1000)
     };
-    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   beforeDestroy () {
     clearInterval(this.envTimer)

--- a/src/components/projects/guide/helm/basicInfo.vue
+++ b/src/components/projects/guide/helm/basicInfo.vue
@@ -89,7 +89,7 @@ export default {
   },
   created () {
     bus.$emit(`show-sidebar`, true)
-    bus.$emit(`set-topbar-title`, { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit(`set-topbar-title`, { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   components: {
     Step

--- a/src/components/projects/guide/helm/delivery.vue
+++ b/src/components/projects/guide/helm/delivery.vue
@@ -181,7 +181,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: '' }
+        { title: this.projectName, isProjectName: true, url: '' }
       ]
     })
 

--- a/src/components/projects/guide/helm/runtime.vue
+++ b/src/components/projects/guide/helm/runtime.vue
@@ -274,7 +274,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: '' }
+        { title: this.projectName, isProjectName: true, url: '' }
       ]
     })
 

--- a/src/components/projects/guide/host/hostConfig.vue
+++ b/src/components/projects/guide/host/hostConfig.vue
@@ -66,7 +66,7 @@ export default {
     }
   },
   created () {
-    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   }
 }
 </script>

--- a/src/components/projects/guide/k8s/basicInfo.vue
+++ b/src/components/projects/guide/k8s/basicInfo.vue
@@ -88,7 +88,7 @@ export default {
     }
   },
   created () {
-    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   components: {
     Step

--- a/src/components/projects/guide/k8s/delivery.vue
+++ b/src/components/projects/guide/k8s/delivery.vue
@@ -170,7 +170,7 @@ export default {
   },
   created () {
     this.getWorkflows()
-    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   components: {
     Step,

--- a/src/components/projects/guide/k8s/service.vue
+++ b/src/components/projects/guide/k8s/service.vue
@@ -44,7 +44,7 @@ export default {
 
   },
   mounted () {
-    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   components: {
     Step,

--- a/src/components/projects/guide/pm/config.vue
+++ b/src/components/projects/guide/pm/config.vue
@@ -81,7 +81,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: '' }
+        { title: this.projectName, isProjectName: true, url: '' }
       ]
     })
   },

--- a/src/components/projects/guide/pm/delivery.vue
+++ b/src/components/projects/guide/pm/delivery.vue
@@ -181,7 +181,7 @@ export default {
   },
   created () {
     this.getWorkflows()
-    bus.$emit(`set-topbar-title`, { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit(`set-topbar-title`, { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   components: {
     Step,

--- a/src/components/projects/guide/pm/deploy.vue
+++ b/src/components/projects/guide/pm/deploy.vue
@@ -205,7 +205,7 @@ export default {
         this.generateEnv(this.projectName)
       }, 1000)
     };
-    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   beforeDestroy () {
     clearInterval(this.envTimer)

--- a/src/components/projects/guide/pm/info.vue
+++ b/src/components/projects/guide/pm/info.vue
@@ -88,7 +88,7 @@ export default {
     }
   },
   created () {
-    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: '' }] })
+    bus.$emit('set-topbar-title', { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: '' }] })
   },
   components: {
     Step

--- a/src/components/projects/policy/home.vue
+++ b/src/components/projects/policy/home.vue
@@ -244,6 +244,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         { title: '协作模式', url: '' }

--- a/src/components/projects/rbac/member.vue
+++ b/src/components/projects/rbac/member.vue
@@ -257,6 +257,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         { title: '权限管理', url: '' },

--- a/src/components/projects/rbac/policy.vue
+++ b/src/components/projects/rbac/policy.vue
@@ -77,6 +77,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         { title: '权限管理', url: '' },

--- a/src/components/projects/rbac/role.vue
+++ b/src/components/projects/rbac/role.vue
@@ -86,7 +86,7 @@ export default {
   },
   created () {
     this.getRoles()
-    bus.$emit(`set-topbar-title`, { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, url: `/v1/projects/detail/${this.projectName}/detail` }, { title: '权限管理', url: '' }, { title: '角色管理', url: '' }] })
+    bus.$emit(`set-topbar-title`, { title: '', breadcrumb: [{ title: '项目', url: '/v1/projects' }, { title: this.projectName, isProjectName: true, url: `/v1/projects/detail/${this.projectName}/detail` }, { title: '权限管理', url: '' }, { title: '角色管理', url: '' }] })
   }
 }
 </script>

--- a/src/components/projects/serviceMgr/service.vue
+++ b/src/components/projects/serviceMgr/service.vue
@@ -49,6 +49,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         { title: '服务', url: '' }

--- a/src/components/projects/test/common/function/function.vue
+++ b/src/components/projects/test/common/function/function.vue
@@ -204,6 +204,7 @@ export default {
           { title: '项目', url: '/v1/projects' },
           {
             title: this.projectName,
+            isProjectName: true,
             url: `/v1/projects/detail/${this.projectName}/detail`
           },
           { title: '测试', url: '' }

--- a/src/components/projects/test/common/function/functionDetail.vue
+++ b/src/components/projects/test/common/function/functionDetail.vue
@@ -230,6 +230,7 @@ export default {
         { title: '项目', url: `/v1/projects` },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}`
         },
         {

--- a/src/components/projects/test/function/functionSummary.vue
+++ b/src/components/projects/test/function/functionSummary.vue
@@ -23,7 +23,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: `/v1/projects/detail/${this.projectName}/detail` },
+        { title: this.projectName, isProjectName: true, url: `/v1/projects/detail/${this.projectName}/detail` },
         { title: '测试', url: `/v1/projects/detail/${this.projectName}/test/function` },
         { title: this.workflowName, url: '' }]
     })

--- a/src/components/projects/test/function/functionTaskDetail.vue
+++ b/src/components/projects/test/function/functionTaskDetail.vue
@@ -27,7 +27,7 @@ export default {
         title: '',
         breadcrumb: [
           { title: '项目', url: '/v1/projects' },
-          { title: this.projectName, url: `/v1/projects/detail/${this.projectName}/detail` },
+          { title: this.projectName, isProjectName: true, url: `/v1/projects/detail/${this.projectName}/detail` },
           { title: '测试', url: `/v1/projects/detail/${this.projectName}/test/function` },
           { title: this.workflowName, url: `/v1/projects/detail/${this.projectName}/test/detail/function/${this.workflowName}` },
           { title: `#${this.taskID}`, url: '' }]

--- a/src/components/projects/test/report/productWorkflowTestCase.vue
+++ b/src/components/projects/test/report/productWorkflowTestCase.vue
@@ -148,7 +148,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: `/v1/projects/detail/${this.projectName}/detail` },
+        { title: this.projectName, isProjectName: true, url: `/v1/projects/detail/${this.projectName}/detail` },
         { title: '工作流', url: `/v1/projects/detail/${this.projectName}/pipelines` },
         { title: this.workflowName, url: `/v1/projects/detail/${this.projectName}/pipelines/multi/${this.workflowName}` },
         { title: `#${this.taskId}`, url: `/v1/projects/detail/${this.projectName}/pipelines/multi/${this.workflowName}/${this.taskId}` },

--- a/src/components/projects/test/report/testCase.vue
+++ b/src/components/projects/test/report/testCase.vue
@@ -29,7 +29,7 @@ export default {
       title: '',
       breadcrumb: [
         { title: '项目', url: '/v1/projects' },
-        { title: this.projectName, url: `/v1/projects/detail/${this.projectName}/detail` },
+        { title: this.projectName, isProjectName: true, url: `/v1/projects/detail/${this.projectName}/detail` },
         { title: '测试', url: `/v1/projects/detail/${this.projectName}/test/function` },
         { title: this.workflowName, url: `/v1/projects/detail/${this.projectName}/test/detail/function/${this.workflowName}` },
         { title: `#${this.taskId}`, url: `/v1/projects/detail/${this.projectName}/test/detail/function/${this.workflowName}/${this.taskId}` },

--- a/src/components/projects/workflow/commonTaskDetail.vue
+++ b/src/components/projects/workflow/commonTaskDetail.vue
@@ -544,6 +544,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         {

--- a/src/components/projects/workflow/list.vue
+++ b/src/components/projects/workflow/list.vue
@@ -196,6 +196,7 @@ export default {
             { title: '项目', url: '/v1/projects' },
             {
               title: this.projectName,
+              isProjectName: true,
               url: `/v1/projects/detail/${this.projectName}/detail`
             },
             { title: '工作流', url: '' }
@@ -406,6 +407,7 @@ export default {
           { title: '项目', url: '/v1/projects' },
           {
             title: this.projectName,
+            isProjectName: true,
             url: `/v1/projects/detail/${this.projectName}/detail`
           },
           { title: '工作流', url: '' }

--- a/src/components/projects/workflow/productDetail.vue
+++ b/src/components/projects/workflow/productDetail.vue
@@ -330,6 +330,7 @@ export default {
         { title: '项目', url: '/v1/projects' },
         {
           title: this.projectName,
+          isProjectName: true,
           url: `/v1/projects/detail/${this.projectName}/detail`
         },
         {

--- a/src/components/projects/workflow/productTaskDetail.vue
+++ b/src/components/projects/workflow/productTaskDetail.vue
@@ -932,6 +932,7 @@ export default {
           { title: '项目', url: '/v1/projects' },
           {
             title: this.projectName,
+            isProjectName: true,
             url: `/v1/projects/detail/${this.projectName}/detail`
           },
           {


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

Breadcrumb supports show project alias.

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/6907296/163325472-3d7548fd-c39c-4147-a173-2c0afe297f8f.png">


### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code