### PR TITLE
fix: add build for shared services cannot be clicked

### DIFF
--- a/src/components/projects/serviceMgr/k8s/serviceAside.vue
+++ b/src/components/projects/serviceMgr/k8s/serviceAside.vue
@@ -93,7 +93,7 @@
                     >
                       <el-button size="small" type="text">{{scope.row.build_name}}</el-button>
                     </router-link>
-                    <el-button v-else size="small" @click="addBuild(scope.row)" type="text">添加构建</el-button>
+                    <el-button v-else size="small" :disabled="projectName !== projectNameOfService" @click="addBuild(scope.row)" type="text">添加构建</el-button>
                   </template>
                 </el-table-column>
               </el-table>


### PR DESCRIPTION
Signed-off-by: Jody <qizhaodi@koderover.com>

### What this PR does / Why we need it:

fix: add build for shared services cannot be clicked


### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information