### PR TITLE
fix(typo):fix typo of vars 

### DIFF
--- a/src/components/projects/build/envVariable.vue
+++ b/src/components/projects/build/envVariable.vue
@@ -235,25 +235,25 @@ export default {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_PR',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用的代码 Pull Request 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval PR=${${REPO_0}_PR} 方式获取第一个代码库的 Pull Request 信息'
+          desc: '构建时使用的代码 Pull Request 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval PR=\${${REPO_0}_PR} 方式获取第一个代码库的 Pull Request 信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_BRANCH',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval BRANCH=${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
+          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval BRANCH=\${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_TAG',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用代码 Tag 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval TAG=${${REPO_0}_TAG} 方式获取第一个代码库的分支信息'
+          desc: '构建时使用代码 Tag 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval TAG=\${${REPO_0}_TAG} 方式获取第一个代码库的分支信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_COMMIT_ID',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用代码 Commit 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index]变量使用，比如可以通过 eval COMMITID=${${REPO_0}_COMMIT_ID} 方式获取第一个代码库的 COMMIT 信息'
+          desc: '构建时使用代码 Commit 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index]变量使用，比如可以通过 eval COMMITID=\${${REPO_0}_COMMIT_ID} 方式获取第一个代码库的 COMMIT 信息'
         }
       ],
       testVars: [

--- a/src/components/projects/build/envVariable.vue
+++ b/src/components/projects/build/envVariable.vue
@@ -241,7 +241,7 @@ export default {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_BRANCH',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval PR=${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
+          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval BRANCH=${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string

--- a/src/components/templateLibrary/builds/envVariable.vue
+++ b/src/components/templateLibrary/builds/envVariable.vue
@@ -241,7 +241,7 @@ export default {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_BRANCH',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval PR=${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
+          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval BRANCH=${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string

--- a/src/components/templateLibrary/builds/envVariable.vue
+++ b/src/components/templateLibrary/builds/envVariable.vue
@@ -235,25 +235,25 @@ export default {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_PR',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用的代码 Pull Request 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval PR=${${REPO_0}_PR} 方式获取第一个代码库的 Pull Request 信息'
+          desc: '构建时使用的代码 Pull Request 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval PR=\${${REPO_0}_PR} 方式获取第一个代码库的 Pull Request 信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_BRANCH',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval BRANCH=${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
+          desc: '构建时使用的代码分支信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval BRANCH=\${${REPO_0}_BRANCH} 方式获取第一个代码库的分支信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_TAG',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用代码 Tag 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval TAG=${${REPO_0}_TAG} 方式获取第一个代码库的分支信息'
+          desc: '构建时使用代码 Tag 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index 变量使用，比如可以通过 eval TAG=\${${REPO_0}_TAG} 方式获取第一个代码库的分支信息'
         },
         {
           // eslint-disable-next-line no-template-curly-in-string
           variable: '$<REPO>_COMMIT_ID',
           // eslint-disable-next-line no-template-curly-in-string
-          desc: '构建时使用代码 Commit 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index]变量使用，比如可以通过 eval COMMITID=${${REPO_0}_COMMIT_ID} 方式获取第一个代码库的 COMMIT 信息'
+          desc: '构建时使用代码 Commit 信息，其中 <REPO> 是具体的代码仓库名称，使用时可以填写仓库名称或者结合 $REPO_index]变量使用，比如可以通过 eval COMMITID=\${${REPO_0}_COMMIT_ID} 方式获取第一个代码库的 COMMIT 信息'
         }
 
       ],


### PR DESCRIPTION
### What this PR does / Why we need it:

[fix(typo):fix typo of vars](https://github.com/koderover/zadig-portal/commit/170f6c335abbbfd947d4998d72413f9ae370df65)

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code