### PR TITLE
fix typo: delete codehub

### DIFF
--- a/src/components/setting/integration/code.vue
+++ b/src/components/setting/integration/code.vue
@@ -509,7 +509,7 @@
           <el-alert type="info"
                     :closable="false">
             <template>
-              支持集成代码源，支持 GitLab、GitHub、CodeHub、Gerrit、Gitee 集成，详情可参考
+              支持集成代码源，支持 GitLab、GitHub、Gerrit、Gitee 集成，详情可参考
               <el-link style="font-size: 14px; vertical-align: baseline;"
                        type="primary"
                        :href="`https://docs.koderover.com/zadig/settings/codehost/gitlab/`"


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:

we don't support CodeHub integration for now.

### What is changed and how it works?

How it Works: delete CodeHub info

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information