### PR TITLE
cherry-pick:#1006

### DIFF
--- a/src/components/projects/workflow/productTaskDetail.vue
+++ b/src/components/projects/workflow/productTaskDetail.vue
@@ -379,21 +379,19 @@
 
           <el-table-column label="分发" min-width="250px">
             <template slot-scope="scope">
-              <span :class="colorTranslation(scope.row.release_imageSubTask.distribute_info[0].distribute_status, 'pipeline', 'task')">{{ myTranslate(scope.row.release_imageSubTask.distribute_info[0].distribute_status) }}</span>
-              <!-- {{ makePrettyElapsedTime(scope.row) }}
-              <el-tooltip v-if="calcElapsedTimeNum(scope.row)<0" content="本地系统时间和服务端可能存在不一致，请同步。" placement="top">
-                <i class="el-icon-warning" style="color: red;"></i>
-              </el-tooltip> -->
+              <template  v-if="scope.row.release_imageSubTask">
+                <span :class="colorTranslation(scope.row.release_imageSubTask.distribute_info[0].distribute_status, 'pipeline', 'task')">{{'镜像：' + myTranslate(scope.row.release_imageSubTask.distribute_info[0].distribute_status) }}</span>
+              </template>
+              <template v-if="scope.row.distribute2kodoSubTask">
+                <span :class="colorTranslation(scope.row.distribute2kodoSubTask.status, 'pipeline', 'task')">{{ '对象存储：' + myTranslate(scope.row.distribute2kodoSubTask.status) }}</span>
+              </template>
             </template>
           </el-table-column>
 
           <el-table-column label="部署" min-width="250px">
             <template slot-scope="scope">
-              <span v-if="checkDistributeDeploy(scope.row.release_imageSubTask.distribute_info)" :class="colorTranslation(scope.row.release_imageSubTask.distribute_info[0].deploy_status, 'pipeline', 'task')">{{ myTranslate(scope.row.release_imageSubTask.distribute_info[0].deploy_status) }}</span>
-              <!-- {{ makePrettyElapsedTime(scope.row) }}
-              <el-tooltip v-if="calcElapsedTimeNum(scope.row)<0" content="本地系统时间和服务端可能存在不一致，请同步。" placement="top">
-                <i class="el-icon-warning" style="color: red;"></i>
-              </el-tooltip> -->
+              <span v-if="scope.row.release_imageSubTask && checkDistributeDeploy(scope.row.release_imageSubTask.distribute_info)" :class="colorTranslation(scope.row.release_imageSubTask.distribute_info[0].deploy_status, 'pipeline', 'task')">{{ myTranslate(scope.row.release_imageSubTask.distribute_info[0].deploy_status) }}</span>
+              <span v-else>N/A</span>
             </template>
           </el-table-column>
         </el-table>

--- a/src/components/projects/workflow/productTaskDetail/distributeDeploy.vue
+++ b/src/components/projects/workflow/productTaskDetail/distributeDeploy.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="task-detail-distribute">
-    <el-card class="box-card task-process" :body-style="{ margin: '15px 0 0 0' }">
+    <el-card  v-if="distributeDeploy.release_imageSubTask" class="box-card task-process" :body-style="{ margin: '15px 0 0 0' }">
       <div class="error-wrapper">
         <el-alert
           v-if="distributeDeploy.release_imageSubTask.error"
@@ -207,18 +207,6 @@ export default {
   data () {
     return {}
   },
-  methods: {
-    // serviceUrl (deploy) {
-    //   const path = `/v1/projects/detail/${distributeDeploy.product_name}/envs/detail/${distributeDeploy.service_name}`
-    //   const query = {
-    //     envName: distributeDeploy.env_name,
-    //     projectName: distributeDeploy.product_name,
-    //     namespace: distributeDeploy.namespace,
-    //     clusterId: distributeDeploy.cluster_id ? distributeDeploy.cluster_id : ''
-    //   }
-    //   return path + '?' + qs.stringify(query)
-    // }
-  },
   props: {
     distributeDeploy: {
       type: Object,
@@ -227,11 +215,15 @@ export default {
   },
   computed: {
     deployInfo () {
-      return this.distributeDeploy.release_imageSubTask.distribute_info.filter(
-        item => {
-          return item.deploy_enabled
-        }
-      )
+      if (this.distributeDeploy.release_imageSubTask) {
+        return this.distributeDeploy.release_imageSubTask.distribute_info.filter(
+          item => {
+            return item.deploy_enabled
+          }
+        )
+      } else {
+        return []
+      }
     }
   }
 }

--- a/src/components/projects/workflow/workflowEditor/productWorkflow/modules/distribute.vue
+++ b/src/components/projects/workflow/workflowEditor/productWorkflow/modules/distribute.vue
@@ -17,7 +17,7 @@
           </el-select>
         </el-form-item>
         <el-form-item label="分发方式">
-          <el-select v-model="distributeStageDetail.methods" @change="changeReleaseMethod" multiple size="small">
+          <el-select v-model="distributeStageDetail.methods" @change="changeReleaseMethod"  @remove-tag="removeReleaseMethod" multiple size="small">
             <el-option label="镜像分发" value="image"></el-option>
             <el-option label="对象存储分发" value="object"></el-option>
           </el-select>
@@ -231,7 +231,6 @@ export default {
           errors.push('image')
         }
       }
-      console.log(errors)
       if (errors.length === 0) {
         bus.$emit('receive-tab-check:distribute', true)
         this.$emit('saveDistributeDeploy', this.distributeStageDetail)
@@ -261,6 +260,14 @@ export default {
             repo_id: ''
           }
         ])
+      }
+    },
+    removeReleaseMethod (val) {
+      if (val === 'object') {
+        this.$set(this.distributeStageDetail, 's3_storage_id', '')
+      }
+      if (val === 'image') {
+        this.$set(this.distributeStageDetail, 'releases', [])
       }
     }
   },


### PR DESCRIPTION
### What this PR does / Why we need it:

cherry-pick:#1006
- `release_imageSubTask` is undefined when the release method is `object`.
-  fix release method removal not working in workflow's release page.

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/6907296/175763968-a8d02572-0ced-45a9-ab52-141a0a54b2ec.png">


### Check List <!--REMOVE the items that are not applicable-->

- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
