### PR TITLE
fix typo: missing $ before variable BUILD_URL

### DIFF
--- a/src/components/projects/workflow/workflowEditor/customWorkflow/config.js
+++ b/src/components/projects/workflow/workflowEditor/customWorkflow/config.js
@@ -91,7 +91,7 @@ const buildEnvs = [
     desc: '工作流任务 ID'
   },
   {
-    variable: 'BUILD_URL',
+    variable: '$BUILD_URL',
     desc: '构建任务的 URL'
   },
   {


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: missing $ before variable BUILD_URL in common workflow

### What is changed and how it works?

What's Changed: add the missing $

- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code