### PR TITLE
fix typo: remove useless variable

### DIFF
--- a/src/components/projects/build/envVariable.vue
+++ b/src/components/projects/build/envVariable.vue
@@ -212,10 +212,6 @@ export default {
           desc: '构建的服务名称'
         },
         {
-          variable: '$DIST_DIR',
-          desc: '构建出的 Tar 包的目的目录'
-        },
-        {
           variable: '$ENV_NAME',
           desc: '执行的环境名称'
         },

--- a/src/components/projects/workflow/workflowEditor/commonWorkflow/modules/build.vue
+++ b/src/components/projects/workflow/workflowEditor/commonWorkflow/modules/build.vue
@@ -153,7 +153,6 @@
             <br />$TASK_ID&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;工作流任务 ID
             <br />$IMAGE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;输出镜像名称
             <br />$SERVICE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;构建的服务名称
-            <br />$DIST_DIR&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;构建出的 Tar 包的目的目录
             <br />$PKG_FILE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;构建出的 Tar 包名称
             <br />$ENV_NAME&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;执行的环境名称
             <br />$BUILD_URL&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;构建任务的 URL

--- a/src/components/templateLibrary/builds/envVariable.vue
+++ b/src/components/templateLibrary/builds/envVariable.vue
@@ -202,10 +202,6 @@ export default {
           desc: '构建的服务名称'
         },
         {
-          variable: '$DIST_DIR',
-          desc: '构建出的 Tar 包的目的目录'
-        },
-        {
           variable: '$ENV_NAME',
           desc: '执行的环境名称'
         },


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:
 variable `$DIST_DIR` is no longer in use.

### What is changed and how it works?

remove variable `$DIST_DIR`

### Check List <!--REMOVE the items that are not applicable-->

- [x] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information

document ref: https://github.com/koderover/zadig-doc/pull/368