### PR TITLE
fix typo: [cherri-pick 1098]keep typo consistent

### DIFF
--- a/src/components/projects/workflow/workflowEditor/customWorkflow/components/plugin.vue
+++ b/src/components/projects/workflow/workflowEditor/customWorkflow/components/plugin.vue
@@ -55,9 +55,9 @@
             <EnvTypeSelect v-model="scope.row.command" isFixed isRuntime isOther style="display: inline-block;" />
           </template>
         </el-table-column>
-        <el-table-column label="是否加密">
+        <el-table-column label="敏感信息">
           <template slot-scope="scope">
-            <el-checkbox v-model="scope.row.is_credential" :disabled="scope.row.type === 'text'">是否加密</el-checkbox>
+            <el-checkbox v-model="scope.row.is_credential" :disabled="scope.row.type === 'text'"></el-checkbox>
           </template>
         </el-table-column>
       </el-table>


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:
keep typo consistent, ref: https://github.com/koderover/zadig-portal/pull/1098

### What is changed and how it works?

What's Changed: `是否加密` -> `敏感信息`

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information