### PR TITLE
fix(style):remove margin in el-alert__description

### DIFF
--- a/src/assets/css/common/common.less
+++ b/src/assets/css/common/common.less
@@ -2,7 +2,7 @@
   padding: 8px 0;
 
   .el-alert__description {
-    margin: 5px 0 0;
+    margin: 0 0;
     font-size: 14px;
   }
 }

--- a/src/assets/css/theme/index.css
+++ b/src/assets/css/theme/index.css
@@ -4977,7 +4977,7 @@
 }
 .el-alert .el-alert__description {
   font-size: 12px;
-  margin: 5px 0 0;
+  margin: 0;
 }
 .el-alert__closebtn {
   font-size: 12px;


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

fix(style):remove margin in el-alert__description

### What is changed and how it works?
before:
<img width="666" alt="image" src="https://user-images.githubusercontent.com/6907296/188349989-445ccf96-a07e-4366-b268-763731e0a82c.png">

after:
<img width="665" alt="image" src="https://user-images.githubusercontent.com/6907296/188349879-f3e88f78-dc97-4cdd-9670-2854f48f870f.png">

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
