### PR TITLE
fix typo: update codehost integration ref link

### DIFF
--- a/src/components/setting/integration/code.vue
+++ b/src/components/setting/integration/code.vue
@@ -587,7 +587,7 @@
               支持集成代码源，支持 GitLab、GitHub、Gerrit、Gitee 集成，详情可参考
               <el-link style="font-size: 14px; vertical-align: baseline;"
                        type="primary"
-                       :href="`https://docs.koderover.com/zadig/settings/codehost/gitlab/`"
+                       :href="`https://docs.koderover.com/zadig/settings/codehost/overview/`"
                        :underline="false"
                        target="_blank">帮助文档</el-link> 。
             </template>


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

document pull request: https://github.com/koderover/zadig-doc/pull/396

### What this PR does / Why we need it:

update codehost integration ref link( to make it more precise)

<img width="1144" alt="image" src="https://user-images.githubusercontent.com/89375976/195241603-f37f206f-0a14-48f4-b809-5273b933cf3a.png">

- [x] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information