### PR TITLE
fix typo: fix link

### DIFF
--- a/src/components/setting/integration/code.vue
+++ b/src/components/setting/integration/code.vue
@@ -587,7 +587,7 @@
               支持集成代码源，支持 GitLab、GitHub、Gerrit、Gitee 集成，详情可参考
               <el-link style="font-size: 14px; vertical-align: baseline;"
                        type="primary"
-                       :href="`https://docs.koderover.com/zadig/settings/codehost/overview/`"
+                       :href="`https://docs.koderover.com/zadig/settings/codehost/overview`"
                        :underline="false"
                        target="_blank">帮助文档</el-link> 。
             </template>


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:

fix link: `/` at the end of link will lead to 404

### What is changed and how it works?

What's Changed: remove `/`


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information