### PR TITLE
fix:set project prop to current project by default.

### DIFF
--- a/src/components/projects/workflow/workflowEditor/customWorkflow/index.vue
+++ b/src/components/projects/workflow/workflowEditor/customWorkflow/index.vue
@@ -420,6 +420,7 @@ export default {
   },
   methods: {
     init () {
+      this.payload.project = this.projectName
       this.getServiceAndBuildList()
       this.setTitle()
       if (this.modelId) {

--- a/src/components/projects/workflow/workflowEditor/releaseWorkflow/index.vue
+++ b/src/components/projects/workflow/workflowEditor/releaseWorkflow/index.vue
@@ -477,6 +477,7 @@ export default {
   },
   methods: {
     init () {
+      this.payload.project = this.projectName
       this.getServiceAndBuildList()
       this.setTitle()
       if (this.modelId) {


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

fix:set project prop to current project by default.

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
