### PR TITLE
fix:remove the min-width limit of the k8s yml pane to make dragging more flexible.

### DIFF
--- a/src/assets/css/component/service-mgr.less
+++ b/src/assets/css/component/service-mgr.less
@@ -66,8 +66,6 @@
     .service-tree-container {
       display: flex;
       flex-direction: column;
-      min-width: 250px;
-      max-width: 480px;
       height: 100%;
       box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.05);
     }
@@ -152,8 +150,7 @@
     }
 
     .service-aside-right {
-      min-width: 372px;
-      -webkit-transition: width 0.2s ease-out;
+      // min-width: 372px;
       transition: width 0.2s ease-out;
     }
 

--- a/src/components/projects/serviceMgr/serviceK8s.vue
+++ b/src/components/projects/serviceMgr/serviceK8s.vue
@@ -89,7 +89,7 @@
             <template v-if="service.service_name  &&  services.length >0">
                 <MultipaneResizer/>
                 <div class="service-editor-container"
-                     :style="{ minWidth: '300px', width: middleWidth }">
+                     :style="{ minWidth: '0px'}">
                   <ServiceEditor ref="serviceEditor"
                                     :serviceInTree="service"
                                     :showNext.sync="showNext"


### PR DESCRIPTION
### What this PR does / Why we need it:

fix:remove the min-width limit of the k8s yml pane to make dragging more flexible.

### Check List <!--REMOVE the items that are not applicable-->

- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
