### PR TITLE
fix:use the latest view name after editing the view.

### DIFF
--- a/src/components/projects/workflow/list.vue
+++ b/src/components/projects/workflow/list.vue
@@ -547,14 +547,15 @@ export default {
             })
           } else {
             params.id = this.presetWorkflowInfo.id
+            this.view = this.workflowViewForm.name
             editWorkflowViewAPI(params, this.projectName).then(res => {
               this.$message({
                 message: this.$t(`workflow.updateSuccess`),
                 type: 'success'
               })
-              this.$refs[formName].resetFields()
               this.getWorkflows(this.projectName)
               this.getWorkflowViewList()
+              this.$refs[formName].resetFields()
             })
           }
           this.showWorkflowViewDialog = false


### PR DESCRIPTION
### What this PR does / Why we need it:

fix:use the latest view name after editing the view.

### Check List <!--REMOVE the items that are not applicable-->

- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
